### PR TITLE
DOP-1265: add Flink sql handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ With this, the first document in the users collection would output the following
     "contact_email_address": "jsmith123@gmail.com",
     "contact_phone_number": 1234567890,
     "connections": "['jdoe456','elowry789']",
-    "visits": "[{'seen_at': '2022-12-15T20:24:26.637Z','count': 3]"
+    "visits": "[{'seen_at': '2022-12-15T20:24:26.637Z','count': 3}]"
 }
 ```
 

--- a/relationalize/relationalize.py
+++ b/relationalize/relationalize.py
@@ -127,20 +127,20 @@ class Relationalize:
         if isinstance(d, list):
             if len(d) == 0:
                 return {path: None}
-            else:
-                if self.stringify_arrays:
-                    d_str = str(d)
-                    return {path: d_str}
-                else:
-                    id = Relationalize._generate_rid()
-                    for index, row in enumerate(d):
-                        key_path = path
-                        if table_path:
-                            key_path = table_path
-                        self._write_to_output(
-                            key=f"{key_path}", content=self._list_helper(id, index, row, path=path), is_sub=True
-                        )
-                    return {path: id}
+            
+            if self.stringify_arrays:
+                d_str = str(d)
+                return {path: d_str}
+
+            id = Relationalize._generate_rid()
+            for index, row in enumerate(d):
+                key_path = path
+                if table_path:
+                    key_path = table_path
+                self._write_to_output(
+                    key=f"{key_path}", content=self._list_helper(id, index, row, path=path), is_sub=True
+                )
+            return {path: id}
             
         if isinstance(d, dict):
             temp_d: dict[str, object] = {}
@@ -156,7 +156,6 @@ class Relationalize:
     def close_io(self) -> None:
         for file_object in self.outputs.values():
             file_object.close()
-        self.outputs.clear() 
 
     @staticmethod
     def _generate_rid() -> str:

--- a/relationalize/schema.py
+++ b/relationalize/schema.py
@@ -385,17 +385,16 @@ class Schema(Generic[DialectColumnType]):
         """
         Get the type of a given value
         """
+        if isinstance(value, str):
+            return parse_type_string(value)
         if isinstance(value, bool):
             return "bool"
         if isinstance(value, int):
             return parse_type_int(value)
         if isinstance(value, float):
             if value.is_integer():
-                return parse_type_int(value)
-            else:
-                return "float"
-        if isinstance(value, str):
-            return parse_type_string(value)
+                return parse_type_int(int(value))
+            return "float"
         if value is None:
             return "none"
         return UnsupportedColumnType(f"{Schema._UNSUPPORTED_SEQUENCE}{type(value)}")

--- a/relationalize/sql_dialects.py
+++ b/relationalize/sql_dialects.py
@@ -80,3 +80,53 @@ CREATE TABLE IF NOT EXISTS "{schema}"."{table_name}" (
         if is_primary:
             column_str = f'"{cleaned_column_name}" {column_type} {postgres_column_param["primary_key"]}'
         return DDLColumn(column_str)
+
+
+# Flink SQL #
+
+FlinkColumnType = Literal[
+    'BOOLEAN',
+    'INT',
+    'BIGINT',
+    'FLOAT',
+    'STRING',
+    'TIMESTAMP',
+    'TIMESTAMP_LTZ',
+]
+
+flink_column_param: dict[(SupportedColumnParam, str), str] = {
+    "primary_key": "PRIMARY KEY",
+}
+
+class FlinkDialect(SQLDialect[FlinkColumnType]):
+    """
+    Inherits from `SQLDialect` and implements the Flink SQL syntax.
+    """
+
+    type_column_mapping: Mapping[SupportedColumnType, FlinkColumnType] = {
+        "none": "BOOLEAN",
+        "bool": "BOOLEAN",
+        "int": "INT",
+        "bigint": "BIGINT",
+        "float": "FLOAT",
+        "str": "STRING",
+        "datetime": "TIMESTAMP",
+        "datetime_tz": "TIMESTAMP_LTZ",
+    }
+
+    base_ddl: str = """
+CREATE TABLE IF NOT EXISTS "{schema}"."{table_name}" (
+    {columns}
+);
+    """.strip()
+
+    @staticmethod
+    def generate_ddl_column(column_name: str, column_type: FlinkColumnType, is_primary: bool = False):
+        '''
+        is_primary = True adds a primary key constraint to the column. Default is False. Since Flink does not own the data, primary keys will always be in NOT ENFORCED mode. 
+        '''
+        cleaned_column_name = column_name.replace('"', '""')
+        column_str = f'"{cleaned_column_name}" {column_type}'
+        if is_primary:
+            column_str = f'"{cleaned_column_name}" {column_type} {flink_column_param["primary_key"]} NOT ENFORCED'
+        return DDLColumn(column_str)

--- a/relationalize/sql_dialects.py
+++ b/relationalize/sql_dialects.py
@@ -25,7 +25,7 @@ class SQLDialect(ABC, Generic[DialectColumnType]):
     def generate_ddl_column(column_name: str, column_type: DialectColumnType, is_primary: bool = False) -> DDLColumn:
         raise NotImplementedError()
 
-    def generate_ddl(self, schema: str, table_name: str, columns: list[str]):
+    def generate_ddl(self, schema: str, table_name: str, columns: list[str]) -> str:
         """
         Generates a complete "Create Table" statement given the
         schema, table_name, and column definitions.

--- a/relationalize/sql_dialects.py
+++ b/relationalize/sql_dialects.py
@@ -35,14 +35,16 @@ class SQLDialect(ABC, Generic[DialectColumnType]):
             schema=schema, table_name=table_name, columns=columns_str
         )
 
+# PostgreSQL #
 
 PostgresColumnType = Literal[
     'BOOLEAN',
     'INT',
     'BIGINT',
-    'FLOAT',
-    'VARCHAR(65535)',
-    'TIMESTAMPTZ',
+    'FLOAT',        # FLOAT === FLOAT8 === DOUBLE PRECISION
+    'TEXT',
+    'TIMESTAMP',    # TIMESTAMP WITHOUT TIMEZONE
+    'TIMESTAMPTZ',  # TIMESTAMP WITH TIMEZONE
 ]
 
 postgres_column_param: dict[SupportedColumnParam, str] = {
@@ -60,8 +62,9 @@ class PostgresDialect(SQLDialect[PostgresColumnType]):
         "int": "INT",
         "bigint": "BIGINT",
         "float": "FLOAT",
-        "str": "VARCHAR(65535)",
-        "datetime": "TIMESTAMPTZ",
+        "str": "TEXT",
+        "datetime": "TIMESTAMP",
+        "datetime_tz": "TIMESTAMPTZ",
     }
 
     base_ddl: str = """

--- a/relationalize/types.py
+++ b/relationalize/types.py
@@ -45,8 +45,7 @@ INT_MAX = 2147483647
 def parse_type_int(value: int):
     if value < INT_MIN or value > INT_MAX:
         return 'bigint'
-    else:
-        return 'int'
+    return 'int'
 
 # Initial datetime regex that matches a string starting with "%Y-%m-%d %H:%M:%S" and anything after
 DATETIME_REGEX = r'^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}.*$'
@@ -65,27 +64,24 @@ def parse_type_string(value: str):
     Uncomment the cases relevant to you
     """
     # # check if bool
-    # value_lower = value.lower()
-    # if value_lower in ['true', 'false']:
+    # if value.lower() in ['true', 'false']:
     #     return 'bool'
-    
+
     # # check if int
     # try:
-    #     int(value)
-    #     return 'int'
+    #     int_val = int(value)
+    #     return parse_type_int(int_val)
     # except ValueError:
     #     pass
 
     # # check if float
     # try:
-        # fval = float(value)
-        # if fval.is_integer():
-        #     return "int"
-        # else:
-        #     return "float"
+    #     float_val = float(value)
+    #     if float_val.is_integer():
+    #         return parse_type_int(int(float_val))
+    #     return "float"
     # except ValueError:
     #     pass
-
 
     # Check if in any of the valid datetime formats 
     # First, perform a general datetime format check to limit datetime.strptime calls, improving performance

--- a/relationalize/types.py
+++ b/relationalize/types.py
@@ -28,7 +28,8 @@ BaseSupportedColumnType = Literal[
     'bigint',
     'float',
     'str',
-    'datetime',
+    'datetime',     # without timezone
+    'datetime_tz',  # with timezone
 ]
 SupportedColumnType = BaseSupportedColumnType | ChoiceColumnType
 
@@ -95,7 +96,7 @@ def parse_type_string(value: str):
         for fmt in DATETIME_VALID_FORMATS:
             try:
                 datetime.strptime(value, fmt)
-                return 'datetime'
+                return 'datetime_tz'
             except ValueError:
                 continue
 

--- a/test/relationalize.test.py
+++ b/test/relationalize.test.py
@@ -262,6 +262,16 @@ class RelationalizeTest(unittest.TestCase):
                 json.loads(sub_file_lines[3])["_rid_"],
             )
 
+    def test_stringify_arrays(self):
+        with Relationalize("test_case_6_stringify", create_local_buffer(), stringify_arrays=True) as r:
+            r.relationalize([CASE_6])
+            self.assertListEqual(["test_case_6_stringify"], list(r.outputs.keys()))
+            r.outputs["test_case_6_stringify"].seek(0)
+            self.assertDictEqual(
+                json.loads(r.outputs["test_case_6_stringify"].read()),
+                {"1": str([{"2": "foobar", "3": [1, 2]}, {"2": "barfoo", "3": [3, 4]}]), "2": "foobar"}
+            )
+
     def test_flatten_struct(self):
         with Relationalize("test_case_7", create_local_buffer()) as r:
             r.relationalize([CASE_7])

--- a/test/schema.test.py
+++ b/test/schema.test.py
@@ -28,7 +28,7 @@ CASE_8B = {"1": 1.0, "2": 2.2}
 CASE_1_DDL = """
 CREATE TABLE IF NOT EXISTS "public"."test" (
     "1" INT
-    , "2" VARCHAR(65535)
+    , "2" TEXT
     , "3" BOOLEAN
     , "4" FLOAT
     , "5" BIGINT
@@ -38,9 +38,9 @@ CREATE TABLE IF NOT EXISTS "public"."test" (
 CASE_2_DDL = """
 CREATE TABLE IF NOT EXISTS "public"."test" (
     "1_int" INT
-    , "1_str" VARCHAR(65535)
+    , "1_str" TEXT
     , "2_float" FLOAT
-    , "2_str" VARCHAR(65535)
+    , "2_str" TEXT
     , "3" BOOLEAN
     , "4" FLOAT
     , "5" BIGINT
@@ -49,8 +49,8 @@ CREATE TABLE IF NOT EXISTS "public"."test" (
 
 CASE_6_DDL = """
 CREATE TABLE IF NOT EXISTS "public"."test" (
-    "_id" VARCHAR(65535) PRIMARY KEY
-    , "not_id" VARCHAR(65535)
+    "_id" TEXT PRIMARY KEY
+    , "not_id" TEXT
 );
 """.strip()
 
@@ -62,7 +62,7 @@ CREATE TABLE IF NOT EXISTS "public"."test" (
     , "4" TIMESTAMPTZ
     , "5" TIMESTAMPTZ
     , "6" TIMESTAMPTZ
-    , "7" VARCHAR(65535)
+    , "7" TEXT
 );
 """.strip()
 
@@ -96,7 +96,7 @@ class SchemaTest(unittest.TestCase):
         schema = Schema()
         schema.read_object(CASE_7)
         self.assertDictEqual(
-            {"1": {"type": "datetime", "is_primary": False}, "2": {"type": "datetime", "is_primary": False}, "3": {"type": "datetime", "is_primary": False}, "4": {"type": "datetime", "is_primary": False}, "5": {"type": "datetime", "is_primary": False}, "6": {"type": "datetime", "is_primary": False}, "7": {"type": "str", "is_primary": False}}, 
+            {"1": {"type": "datetime_tz", "is_primary": False}, "2": {"type": "datetime_tz", "is_primary": False}, "3": {"type": "datetime_tz", "is_primary": False}, "4": {"type": "datetime_tz", "is_primary": False}, "5": {"type": "datetime_tz", "is_primary": False}, "6": {"type": "datetime_tz", "is_primary": False}, "7": {"type": "str", "is_primary": False}}, 
             schema.schema
         )
     


### PR DESCRIPTION
- Modify string data type mappings: string => TEXT (~~VARCHAR(65535)~~)
- Add Flink SQL dialect (FlinkDialect)
    - Primary key columns have the `NOT ENFORCED` key word
- Add flexibility for relationalizing arras with the `stringify_arrays` argument in the `Relationalize` class constructor
- Update unit tests and README