### PR TITLE
DOP-1265: rectify flink ddl syntax

### DIFF
--- a/relationalize/schema.py
+++ b/relationalize/schema.py
@@ -138,10 +138,13 @@ class Schema(Generic[DialectColumnType]):
         columns.sort()
         return columns
 
-    def generate_ddl(self, table: str, schema: str = "public", sql_dialect: SQLDialect[DialectColumnType] = DEFAULT_SQL_DIALECT) -> str:
+    def generate_ddl(self, table: str, schema: str = "public", sql_dialect: SQLDialect[DialectColumnType] = DEFAULT_SQL_DIALECT, schema_qualified: bool = True) -> str:
         """
         Generates a CREATE TABLE statement for this schema, breaking out choice columns into separate columns.
+
         The optional `sql_dialect` argument accepts a SQLDialect instance, which determines the SQL dialect for the DDL.
+        
+        The optional `schema_qualified` argument determines if the CREATE TABLE statement specifies a schema-qualified table name.
         """
         columns_pk: list[str] = [] # The primary keys columns in the table being created. There should be at most 1 per table.
         columns_none: list[str] = [] # The columns with the none data type. These are columns that might not need to be created.
@@ -206,7 +209,7 @@ class Schema(Generic[DialectColumnType]):
                 f"These columns are: {columns_multitype}"
             )
 
-        return sql_dialect.generate_ddl(schema, table, columns)
+        return sql_dialect.generate_ddl(schema, table, columns, schema_qualified)
 
     def drop_null_columns(self) -> int:
         """

--- a/relationalize/schema.py
+++ b/relationalize/schema.py
@@ -33,15 +33,13 @@ class Schema(Generic[DialectColumnType]):
     def __init__(
         self,
         schema: dict[str, ColumnDict] | None = None,
-        source_dialect: NoSQLDialect = DEFAULT_SOURCE_DIALECT,              # source dialect
-        sql_dialect: SQLDialect[DialectColumnType] = DEFAULT_SQL_DIALECT,   # target dialect
+        source_dialect: NoSQLDialect = DEFAULT_SOURCE_DIALECT,  # source dialect
         log_level=DEFAULT_LOGLEVEL
     ):
         if schema is None:
             schema = dict()
         self.schema = schema
         self.source_dialect = source_dialect
-        self.sql_dialect = sql_dialect
 
         # Configure logger
         logger = logging.getLogger(self.__class__.__name__)
@@ -140,10 +138,10 @@ class Schema(Generic[DialectColumnType]):
         columns.sort()
         return columns
 
-    def generate_ddl(self, table: str, schema: str = "public") -> str:
+    def generate_ddl(self, table: str, schema: str = "public", sql_dialect: SQLDialect[DialectColumnType] = DEFAULT_SQL_DIALECT) -> str:
         """
-        Generates a CREATE TABLE statement for this schema.
-        Breaking out choice columns into separate columns.
+        Generates a CREATE TABLE statement for this schema, breaking out choice columns into separate columns.
+        The optional `sql_dialect` argument accepts a SQLDialect instance, which determines the SQL dialect for the DDL.
         """
         columns_pk: list[str] = [] # The primary keys columns in the table being created. There should be at most 1 per table.
         columns_none: list[str] = [] # The columns with the none data type. These are columns that might not need to be created.
@@ -162,8 +160,8 @@ class Schema(Generic[DialectColumnType]):
             if Schema._CHOICE_SEQUENCE not in value_type:
                 # Column is not a choice column
                 columns.append(
-                    self.sql_dialect.generate_ddl_column(
-                        key, self.sql_dialect.type_column_mapping[value_type], is_primary
+                    sql_dialect.generate_ddl_column(
+                        key, sql_dialect.type_column_mapping[value_type], is_primary
                     )
                 )
                 if value_type == "none":
@@ -175,9 +173,9 @@ class Schema(Generic[DialectColumnType]):
                 if choice_type == "none":
                     continue
                 columns.append(
-                    self.sql_dialect.generate_ddl_column(
+                    sql_dialect.generate_ddl_column(
                         f"{key}_{choice_type}",
-                        self.sql_dialect.type_column_mapping[choice_type],
+                        sql_dialect.type_column_mapping[choice_type],
                         is_primary
                     )
                 )
@@ -208,7 +206,7 @@ class Schema(Generic[DialectColumnType]):
                 f"These columns are: {columns_multitype}"
             )
 
-        return self.sql_dialect.generate_ddl(schema, table, columns)
+        return sql_dialect.generate_ddl(schema, table, columns)
 
     def drop_null_columns(self) -> int:
         """

--- a/relationalize/sql_dialects.py
+++ b/relationalize/sql_dialects.py
@@ -33,10 +33,9 @@ class SQLDialect(ABC, Generic[DialectColumnType]):
         """
         columns_str = _COLUMN_SEPARATOR.join(columns)
         if schema_qualified:
-            ddl = self.base_ddl_sq.format(schema=schema, table_name=table_name, columns=columns_str)
+            return self.base_ddl_sq.format(schema=schema, table_name=table_name, columns=columns_str)
         else:
-            ddl = self.base_ddl.format(table_name=table_name, columns=columns_str)
-        return ddl
+            return self.base_ddl.format(table_name=table_name, columns=columns_str)
 
 # PostgreSQL #
 

--- a/relationalize/sql_dialects.py
+++ b/relationalize/sql_dialects.py
@@ -14,26 +14,29 @@ class SQLDialect(ABC, Generic[DialectColumnType]):
     Parent class for different sql dialects.
 
     Child classes must implement the `generate_ddl_column` method
-    , and provide `type_column_mapping` and `base_ddl`.
+    , and provide `type_column_mapping`, `base_ddl_sq`, and `base_ddl`.
     """
 
     type_column_mapping: Mapping[SupportedColumnType, DialectColumnType]
-    base_ddl: str
+    base_ddl_sq: str    # DDL with schema-qualified name
+    base_ddl: str       # DDL with just table name
 
     @staticmethod
     @abstractmethod
     def generate_ddl_column(column_name: str, column_type: DialectColumnType, is_primary: bool = False) -> DDLColumn:
         raise NotImplementedError()
 
-    def generate_ddl(self, schema: str, table_name: str, columns: list[str]) -> str:
+    def generate_ddl(self, schema: str, table_name: str, columns: list[str], schema_qualified: bool = True) -> str:
         """
         Generates a complete "Create Table" statement given the
         schema, table_name, and column definitions.
         """
         columns_str = _COLUMN_SEPARATOR.join(columns)
-        return self.base_ddl.format(
-            schema=schema, table_name=table_name, columns=columns_str
-        )
+        if schema_qualified:
+            ddl = self.base_ddl_sq.format(schema=schema, table_name=table_name, columns=columns_str)
+        else:
+            ddl = self.base_ddl.format(table_name=table_name, columns=columns_str)
+        return ddl
 
 # PostgreSQL #
 
@@ -67,11 +70,14 @@ class PostgresDialect(SQLDialect[PostgresColumnType]):
         "datetime_tz": "TIMESTAMPTZ",
     }
 
-    base_ddl: str = """
+    base_ddl_sq: str = """
 CREATE TABLE IF NOT EXISTS "{schema}"."{table_name}" (
     {columns}
-);
-    """.strip()
+);""".strip()
+    base_ddl: str = """
+CREATE TABLE IF NOT EXISTS "{table_name}" (
+    {columns}
+);""".strip()
 
     @staticmethod
     def generate_ddl_column(column_name: str, column_type: PostgresColumnType, is_primary: bool = False):
@@ -101,6 +107,8 @@ flink_column_param: dict[(SupportedColumnParam, str), str] = {
 class FlinkDialect(SQLDialect[FlinkColumnType]):
     """
     Inherits from `SQLDialect` and implements the Flink SQL syntax.
+
+    Table and column names should be enclosed by backticks to be treated as a regular identifier. They must not be enclosed by double quotes.
     """
 
     type_column_mapping: Mapping[SupportedColumnType, FlinkColumnType] = {
@@ -114,11 +122,14 @@ class FlinkDialect(SQLDialect[FlinkColumnType]):
         "datetime_tz": "TIMESTAMP_LTZ",
     }
 
-    base_ddl: str = """
-CREATE TABLE IF NOT EXISTS "{schema}"."{table_name}" (
+    base_ddl_sq: str = """
+CREATE TABLE IF NOT EXISTS {schema}.`{table_name}` (
     {columns}
-);
-    """.strip()
+);""".strip()
+    base_ddl: str = """
+CREATE TABLE IF NOT EXISTS `{table_name}` (
+    {columns}
+);""".strip()
 
     @staticmethod
     def generate_ddl_column(column_name: str, column_type: FlinkColumnType, is_primary: bool = False):
@@ -126,7 +137,7 @@ CREATE TABLE IF NOT EXISTS "{schema}"."{table_name}" (
         is_primary = True adds a primary key constraint to the column. Default is False. Since Flink does not own the data, primary keys will always be in NOT ENFORCED mode. 
         '''
         cleaned_column_name = column_name.replace('"', '""')
-        column_str = f'"{cleaned_column_name}" {column_type}'
+        column_str = f'`{cleaned_column_name}` {column_type}'
         if is_primary:
-            column_str = f'"{cleaned_column_name}" {column_type} {flink_column_param["primary_key"]} NOT ENFORCED'
+            column_str = f'`{cleaned_column_name}` {column_type} {flink_column_param["primary_key"]} NOT ENFORCED'
         return DDLColumn(column_str)

--- a/test/schema.test.py
+++ b/test/schema.test.py
@@ -69,43 +69,54 @@ CREATE TABLE IF NOT EXISTS "public"."test" (
 
 # DDLs expected for dialect = Flink
 CASE_1_DDL_FLINK = """
-CREATE TABLE IF NOT EXISTS "public"."test" (
-    "1" INT
-    , "2" STRING
-    , "3" BOOLEAN
-    , "4" FLOAT
-    , "5" BIGINT
+CREATE TABLE IF NOT EXISTS public.`test` (
+    `1` INT
+    , `2` STRING
+    , `3` BOOLEAN
+    , `4` FLOAT
+    , `5` BIGINT
+);
+""".strip()
+
+# Schema unqualified = False
+CASE_1_DDL_FLINK_UNQUALIFIED = """
+CREATE TABLE IF NOT EXISTS `test` (
+    `1` INT
+    , `2` STRING
+    , `3` BOOLEAN
+    , `4` FLOAT
+    , `5` BIGINT
 );
 """.strip()
 
 CASE_2_DDL_FLINK = """
-CREATE TABLE IF NOT EXISTS "public"."test" (
-    "1_int" INT
-    , "1_str" STRING
-    , "2_float" FLOAT
-    , "2_str" STRING
-    , "3" BOOLEAN
-    , "4" FLOAT
-    , "5" BIGINT
+CREATE TABLE IF NOT EXISTS public.`test` (
+    `1_int` INT
+    , `1_str` STRING
+    , `2_float` FLOAT
+    , `2_str` STRING
+    , `3` BOOLEAN
+    , `4` FLOAT
+    , `5` BIGINT
 );
 """.strip()
 
 CASE_6_DDL_FLINK = """
-CREATE TABLE IF NOT EXISTS "public"."test" (
-    "_id" STRING PRIMARY KEY NOT ENFORCED
-    , "not_id" STRING
+CREATE TABLE IF NOT EXISTS public.`test` (
+    `_id` STRING PRIMARY KEY NOT ENFORCED
+    , `not_id` STRING
 );
 """.strip()
 
 CASE_7_DDL_FLINK = """
-CREATE TABLE IF NOT EXISTS "public"."test" (
-    "1" TIMESTAMP_LTZ
-    , "2" TIMESTAMP_LTZ
-    , "3" TIMESTAMP_LTZ
-    , "4" TIMESTAMP_LTZ
-    , "5" TIMESTAMP_LTZ
-    , "6" TIMESTAMP_LTZ
-    , "7" STRING
+CREATE TABLE IF NOT EXISTS public.`test` (
+    `1` TIMESTAMP_LTZ
+    , `2` TIMESTAMP_LTZ
+    , `3` TIMESTAMP_LTZ
+    , `4` TIMESTAMP_LTZ
+    , `5` TIMESTAMP_LTZ
+    , `6` TIMESTAMP_LTZ
+    , `7` STRING
 );
 """.strip()
 
@@ -238,6 +249,12 @@ class SchemaTest(unittest.TestCase):
                 schema1 = Schema()
                 schema1.read_object(CASE_1)
                 self.assertEqual(expected_ddl, schema1.generate_ddl("test", sql_dialect=dialect()))
+
+    def test_generate_ddl_flink_unqualified(self):
+        expected_ddl = CASE_1_DDL_FLINK_UNQUALIFIED
+        schema1 = Schema()
+        schema1.read_object(CASE_1)
+        self.assertEqual(expected_ddl, schema1.generate_ddl("test", sql_dialect=FlinkDialect(), schema_qualified=False))
 
     def test_generate_ddl_choice(self):
         for dialect in self.sql_dialects:

--- a/test/schema.test.py
+++ b/test/schema.test.py
@@ -7,7 +7,7 @@ from setup_tests import setup_tests
 setup_tests()
 
 from relationalize.schema import Schema
-from relationalize.sql_dialects import FlinkDialect
+from relationalize.sql_dialects import FlinkDialect, PostgresDialect
 
 CASE_1 = {"1": 1, "2": "foobar", "3": False, "4": 1.2, "5": 50000000000}
 
@@ -114,7 +114,7 @@ class SchemaTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.sql_dialects = [
-            None,
+            PostgresDialect,
             FlinkDialect
         ]
 
@@ -228,63 +228,59 @@ class SchemaTest(unittest.TestCase):
     def test_generate_ddl_no_choice(self):
         for dialect in self.sql_dialects:
             with self.subTest(dialect=dialect):
-                if dialect is None:
-                    schema1 = Schema()
+                if dialect is PostgresDialect:
                     expected_ddl = CASE_1_DDL
-                elif dialect == FlinkDialect:
-                    schema1 = Schema(sql_dialect=dialect())
+                elif dialect is FlinkDialect:
                     expected_ddl = CASE_1_DDL_FLINK
                 else:
                     self.fail(f"Subtest failed due to unexpected SQL dialect = {dialect}")
-                
+
+                schema1 = Schema()
                 schema1.read_object(CASE_1)
-                self.assertEqual(expected_ddl, schema1.generate_ddl("test"))
+                self.assertEqual(expected_ddl, schema1.generate_ddl("test", sql_dialect=dialect()))
 
     def test_generate_ddl_choice(self):
         for dialect in self.sql_dialects:
             with self.subTest(dialect=dialect):
-                if dialect is None:
-                    schema1 = Schema()
+                if dialect is PostgresDialect:
                     expected_ddl = CASE_2_DDL
-                elif dialect == FlinkDialect:
-                    schema1 = Schema(sql_dialect=dialect())
+                elif dialect is FlinkDialect:
                     expected_ddl = CASE_2_DDL_FLINK
                 else:
                     self.fail(f"Subtest failed due to unexpected SQL dialect = {dialect}")
 
+                schema1 = Schema()
                 schema1.read_object(CASE_1)
                 schema1.read_object(CASE_2)
-                self.assertEqual(expected_ddl, schema1.generate_ddl("test"))
+                self.assertEqual(expected_ddl, schema1.generate_ddl("test", sql_dialect=dialect()))
 
     def test_generate_ddl_primary_key(self):
         for dialect in self.sql_dialects:
             with self.subTest(dialect=dialect):
-                if dialect is None:
-                    schema1 = Schema()
+                if dialect is PostgresDialect:
                     expected_ddl = CASE_6_DDL
-                elif dialect == FlinkDialect:
-                    schema1 = Schema(sql_dialect=dialect())
+                elif dialect is FlinkDialect:
                     expected_ddl = CASE_6_DDL_FLINK
                 else:
                     self.fail(f"Subtest failed due to unexpected SQL dialect = {dialect}")
 
+                schema1 = Schema()
                 schema1.read_object(CASE_6)
-                self.assertEqual(expected_ddl, schema1.generate_ddl("test"))
+                self.assertEqual(expected_ddl, schema1.generate_ddl("test", sql_dialect=dialect()))
 
     def test_generate_ddl_datetime(self):
         for dialect in self.sql_dialects:
             with self.subTest(dialect=dialect):
-                if dialect is None:
-                    schema1 = Schema()
+                if dialect is PostgresDialect:
                     expected_ddl = CASE_7_DDL
-                elif dialect == FlinkDialect:
-                    schema1 = Schema(sql_dialect=dialect())
+                elif dialect is FlinkDialect:
                     expected_ddl = CASE_7_DDL_FLINK
                 else:
                     self.fail(f"Subtest failed due to unexpected SQL dialect = {dialect}")
 
+                schema1 = Schema()
                 schema1.read_object(CASE_7)
-                self.assertEqual(expected_ddl, schema1.generate_ddl("test"))
+                self.assertEqual(expected_ddl, schema1.generate_ddl("test", sql_dialect=dialect()))
 
     def test_none_cases(self):
         schema1 = Schema()


### PR DESCRIPTION
- refactor sql_dialect from Schema class-level arg to ddl method-level arg
- update unit tests
- switch double quotes for backticks
- add schema_qualified arg for ddl generation flexibility
- update unit tests