### PR TITLE
DOP-1265: add stringify objects behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This library differs from the original tulip/relationalize as follows:
 - Added PRIMARY KEY handling
 - Modified naming conventions
 - Modified and extended data type parsing
-- Flexibility for relationalizing array and object fields with the `stringify_arrays` and  `stringify_objects` arguments in the relationalize class constructor
+- Flexibility for array and object relationalization with the `ignore_arrays` and  `ignore_objects` arguments in the relationalize class constructor
 
 ## JSON Object Collections
 When working with JSON often there are collections of objects with the same or similar structure. For example, in a NoSQL database there may be a collection describing users with the following two documents/objects:
@@ -61,7 +61,7 @@ There are a number of challenges that must be overcome to move this data into a 
 This package provides a solution to all of these challenges with more portability and flexibility, and less limitations than AWS Glue relationalize.
 
 ## How Relationalize works
-The relationalize function recursively navigates the JSON object and splits out new ojects/collections whenever an array is encountered and provides a connection/relation between the objects. You provide the Relationalize class a function which will determine where to write the transformed content. This could be a local file object, a remote (s3) file object, or an in memory buffer. Additionally any nested objects are flattened. Each object that is output by relationalize is a flat JSON object.
+The relationalize function recursively navigates the JSON object and splits out new objects/collections whenever an array is encountered and provides a connection/relation between the objects. You provide the Relationalize class a function which will determine where to write the transformed content. This could be a local file object, a remote (s3) file object, or an in memory buffer. Additionally any nested objects are flattened. Each object that is output by relationalize is a flat JSON object.
 
 This package also provides a `Schema` class which can generate a schema for a collection of flat JSON objects. This schema can be used to handle type ambigouity and generate SQL DDL.
 
@@ -151,8 +151,8 @@ For example the first document in the users collection would output the followin
 
 ### Options
 The relationalize class constructor takes in a few optional arguments:
-- The `stringify_arrays` boolean determines how arrays are relationalized. By default (`False`), whenever an array is encountered, new tables are created and a connection/relation is provided between the objects. Setting `stringify_arrays = True` converts all arrays (including any nested arrays and objects within) to strings.
-- The `stringify_objects` boolean determines how nested objects are relationalized to be flattened. By default (`False`), nested keys are combined into a single key delimited by underscores. Setting `stringify_objects = True` converts all nested objects as a string.
+- The `ignore_arrays` boolean determines whether or not arrays are relationalized. By default (`False`), whenever an array is encountered, new tables are created and a connection/relation is provided between the objects. No action is taken when `ignore_arrays = True`.
+- The `ignore_objects` boolean determines whether or not nested objects are relationalized. By default (`False`), nested keys are combined into a single key delimited by underscores. No action is taken when `ignore_objects = True`.
 - See the [Logging section](#logging) to read about `log_level`.
 
 For example:
@@ -164,7 +164,7 @@ def on_object_write(schema: str, object: dict):
       schemas[schema] = Schema()
   schemas[schema].read_object(object)
 
-with Relationalize('object_name', on_object_write=on_object_write, stringify_arrays=True, stringify_objects=True) as r:
+with Relationalize('object_name', on_object_write=on_object_write, ignore_arrays=True, ignore_objects=True) as r:
     r.relationalize([{...}, {...}])
 ```
 
@@ -174,9 +174,9 @@ With this, the first document in the users collection will output the following 
 {
     "username": "jsmith123",
     "created_at": "Monday, December 15, 2022 at 20:24",
-    "contact": "{'email_address': 'jsmith123@gmail.com', 'phone_number': 1234567890}",
-    "connections": "['jdoe456','elowry789']",
-    "visits": "[{'seen_at': '2022-12-15T20:24:26.637Z','count': 3}]"
+    "contact": {"email_address": "jsmith123@gmail.com", "phone_number": 1234567890},
+    "connections": ["jdoe456","elowry789"],
+    "visits": [{"seen_at": "2022-12-15T20:24:26.637Z","count": 3}]
 }
 ```
 

--- a/relationalize/relationalize.py
+++ b/relationalize/relationalize.py
@@ -21,8 +21,8 @@ class Relationalize:
     """
     A class/utility for relationalizing JSON content.
 
-    stringify_arrays = False by default, causing array fields to be separated into individual tables. Set stringify_arrays = True to relationalize arrays by converting them to a string.
-
+    stringify_arrays = False by default, causing array fields to be separated into individual tables. Set stringify_arrays = True to convert arrays to string.
+    stringify_objects = False by default, causing nested object fields to be flattened. Set stringify_objects = True to convert nested objects to string.
     ```
     with Relationalize('abc') as r:
         r.relationalize([{"a": 1}])
@@ -35,12 +35,14 @@ class Relationalize:
         create_output: Callable[[str], TextIO] = DEFAULT_LOCAL_FILE_CALLABLE,
         on_object_write: Callable[[str, dict[str, Any]], None] = no_op,
         stringify_arrays: bool = False,
+        stringify_objects: bool = False,
         log_level=DEFAULT_LOGLEVEL
     ):
         self.name = name
         self.create_output = create_output
         self.on_object_write = on_object_write
         self.stringify_arrays = stringify_arrays
+        self.stringify_objects = stringify_objects
         self.outputs: dict[str, TextIO] = {}
 
         # Configure logger
@@ -143,6 +145,10 @@ class Relationalize:
             return {path: id}
             
         if isinstance(d, dict):
+            if path != "" and self.stringify_objects:
+                d_str = str(d)
+                return {path: d_str}
+
             temp_d: dict[str, object] = {}
             for key in d:
                 temp_table_path = ""

--- a/relationalize/relationalize.py
+++ b/relationalize/relationalize.py
@@ -21,8 +21,8 @@ class Relationalize:
     """
     A class/utility for relationalizing JSON content.
 
-    stringify_arrays = False by default, causing array fields to be separated into individual tables. Set stringify_arrays = True to convert arrays to string.
-    stringify_objects = False by default, causing nested object fields to be flattened. Set stringify_objects = True to convert nested objects to string.
+    ignore_arrays = False by default, causing array fields to be separated into individual tables. Set ignore_arrays = True to leave arrays unmodified.
+    ignore_objects = False by default, causing nested object fields to be flattened. Set ignore_objects = True to leave nested objects unmodified.
     ```
     with Relationalize('abc') as r:
         r.relationalize([{"a": 1}])
@@ -34,15 +34,15 @@ class Relationalize:
         name: str,
         create_output: Callable[[str], TextIO] = DEFAULT_LOCAL_FILE_CALLABLE,
         on_object_write: Callable[[str, dict[str, Any]], None] = no_op,
-        stringify_arrays: bool = False,
-        stringify_objects: bool = False,
+        ignore_arrays: bool = False,
+        ignore_objects: bool = False,
         log_level=DEFAULT_LOGLEVEL
     ):
         self.name = name
         self.create_output = create_output
         self.on_object_write = on_object_write
-        self.stringify_arrays = stringify_arrays
-        self.stringify_objects = stringify_objects
+        self.ignore_arrays = ignore_arrays
+        self.ignore_objects = ignore_objects
         self.outputs: dict[str, TextIO] = {}
 
         # Configure logger
@@ -130,32 +130,25 @@ class Relationalize:
             if len(d) == 0:
                 return {path: None}
             
-            if self.stringify_arrays:
-                d_str = str(d)
-                return {path: d_str}
-
-            id = Relationalize._generate_rid()
-            for index, row in enumerate(d):
-                key_path = path
-                if table_path:
-                    key_path = table_path
-                self._write_to_output(
-                    key=f"{key_path}", content=self._list_helper(id, index, row, path=path), is_sub=True
-                )
-            return {path: id}
-            
-        if isinstance(d, dict):
-            if path != "" and self.stringify_objects:
-                d_str = str(d)
-                return {path: d_str}
-
-            temp_d: dict[str, object] = {}
-            for key in d:
-                temp_table_path = ""
-                if from_array:
-                    temp_table_path = f"{table_path}{_DELIMITER}{key}"
-                temp_d.update(self._relationalize(d[key], path=f"{path_prefix}{key}", table_path=temp_table_path))
-            return temp_d
+            if not self.ignore_arrays:
+                id = Relationalize._generate_rid()
+                for index, row in enumerate(d):
+                    key_path = path
+                    if table_path:
+                        key_path = table_path
+                    self._write_to_output(
+                        key=f"{key_path}", content=self._list_helper(id, index, row, path=path), is_sub=True
+                    )
+                return {path: id}
+        elif isinstance(d, dict):
+            if path == "" or not self.ignore_objects:
+                temp_d: dict[str, object] = {}
+                for key in d:
+                    temp_table_path = ""
+                    if from_array:
+                        temp_table_path = f"{table_path}{_DELIMITER}{key}"
+                    temp_d.update(self._relationalize(d[key], path=f"{path_prefix}{key}", table_path=temp_table_path))
+                return temp_d
 
         return {path: d}
 

--- a/relationalize/schema.py
+++ b/relationalize/schema.py
@@ -188,7 +188,7 @@ class Schema(Generic[DialectColumnType]):
         pk_count = len(columns_pk)
         if pk_count != 1:
             if pk_count == 0:
-                self.logger.warning(f"The '{table}' table is missing a PRIMARY KEY column.\n")
+                self.logger.info(f"The '{table}' table is missing a PRIMARY KEY column.\n")
             else:
                 self.logger.warning(
                     f"Found {pk_count} column(s) with the PRIMARY KEY param in the '{table}' table when there should only be one.\n" \

--- a/relationalize/schema.py
+++ b/relationalize/schema.py
@@ -188,7 +188,7 @@ class Schema(Generic[DialectColumnType]):
         pk_count = len(columns_pk)
         if pk_count != 1:
             if pk_count == 0:
-                self.logger.info(f"The '{table}' table is missing a PRIMARY KEY column.\n")
+                self.logger.warning(f"The '{table}' table is missing a PRIMARY KEY column.\n")
             else:
                 self.logger.warning(
                     f"Found {pk_count} column(s) with the PRIMARY KEY param in the '{table}' table when there should only be one.\n" \

--- a/relationalize/schema.py
+++ b/relationalize/schema.py
@@ -388,6 +388,10 @@ class Schema(Generic[DialectColumnType]):
         """
         if isinstance(value, str):
             return parse_type_string(value)
+        if isinstance(value, list):
+            return "str_arr"
+        if isinstance(value, dict):
+            return "str_obj"
         if isinstance(value, bool):
             return "bool"
         if isinstance(value, int):

--- a/relationalize/sql_dialects.py
+++ b/relationalize/sql_dialects.py
@@ -122,7 +122,7 @@ class FlinkDialect(SQLDialect[FlinkColumnType]):
     }
 
     base_ddl_sq: str = """
-CREATE TABLE IF NOT EXISTS {schema}.`{table_name}` (
+CREATE TABLE IF NOT EXISTS `{schema}.{table_name}` (
     {columns}
 );""".strip()
     base_ddl: str = """

--- a/relationalize/sql_dialects.py
+++ b/relationalize/sql_dialects.py
@@ -45,6 +45,7 @@ PostgresColumnType = Literal[
     'BIGINT',
     'FLOAT',        # FLOAT === FLOAT8 === DOUBLE PRECISION
     'TEXT',
+    'JSONB',
     'TIMESTAMP',    # TIMESTAMP WITHOUT TIMEZONE
     'TIMESTAMPTZ',  # TIMESTAMP WITH TIMEZONE
 ]
@@ -65,6 +66,8 @@ class PostgresDialect(SQLDialect[PostgresColumnType]):
         "bigint": "BIGINT",
         "float": "FLOAT",
         "str": "TEXT",
+        "str_arr": "JSONB",
+        "str_obj": "JSONB",
         "datetime": "TIMESTAMP",
         "datetime_tz": "TIMESTAMPTZ",
     }
@@ -117,6 +120,8 @@ class FlinkDialect(SQLDialect[FlinkColumnType]):
         "bigint": "BIGINT",
         "float": "FLOAT",
         "str": "STRING",
+        "str_arr": "STRING",
+        "str_obj": "STRING",
         "datetime": "TIMESTAMP",
         "datetime_tz": "TIMESTAMP_LTZ",
     }

--- a/relationalize/types.py
+++ b/relationalize/types.py
@@ -28,6 +28,8 @@ BaseSupportedColumnType = Literal[
     'bigint',
     'float',
     'str',
+    'str_arr',      # stringified array
+    'str_obj',      # stringified object
     'datetime',     # without timezone
     'datetime_tz',  # with timezone
 ]

--- a/test/relationalize.test.py
+++ b/test/relationalize.test.py
@@ -14,7 +14,10 @@ CASE_2 = {"1": "foobar", "2": 9.9, "3": True, "4": 9.5}
 
 CASE_3 = {"1": [1, 2], "2": "foobar"}
 
-CASE_4 = {"1": [{"2": "foobar", "3": 1}, {"2": "barfoo", "3": 3}], "2": "foobar"}
+CASE_4 = {
+    "1": [{"2": "foobar", "3": 1}, {"2": "barfoo", "3": 3}],
+    "2": "foobar"
+}
 
 CASE_5 = {"1": [[1], [2, 3]]}
 
@@ -23,7 +26,7 @@ CASE_6 = {
     "2": "foobar",
 }
 
-CASE_7 = {"1": {"2": 1, "3": "foobar"}}
+CASE_7 = {"1": {"2": 1, "3": "foobar", "4": {"5": "barfoo"}}}
 
 CASE_8 = {"1": [[{"2": 3}, {"2": 4}], [{"2": 5}, {"2": 6}]]}
 
@@ -263,13 +266,13 @@ class RelationalizeTest(unittest.TestCase):
             )
 
     def test_stringify_arrays(self):
-        with Relationalize("test_case_6_stringify", create_local_buffer(), stringify_arrays=True) as r:
+        with Relationalize("test_case_6_stringify_arrays", create_local_buffer(), stringify_arrays=True) as r:
             r.relationalize([CASE_6])
-            self.assertListEqual(["test_case_6_stringify"], list(r.outputs.keys()))
-            r.outputs["test_case_6_stringify"].seek(0)
+            self.assertListEqual(["test_case_6_stringify_arrays"], list(r.outputs.keys()))
+            r.outputs["test_case_6_stringify_arrays"].seek(0)
             self.assertDictEqual(
-                json.loads(r.outputs["test_case_6_stringify"].read()),
-                {"1": str([{"2": "foobar", "3": [1, 2]}, {"2": "barfoo", "3": [3, 4]}]), "2": "foobar"}
+                {"1": str([{"2": "foobar", "3": [1, 2]}, {"2": "barfoo", "3": [3, 4]}]), "2": "foobar"},
+                json.loads(r.outputs["test_case_6_stringify_arrays"].read()),
             )
 
     def test_flatten_struct(self):
@@ -280,8 +283,18 @@ class RelationalizeTest(unittest.TestCase):
             )
             r.outputs["test_case_7"].seek(0)
             self.assertDictEqual(
-                {"1_2": 1, "1_3": "foobar"},
+                {"1_2": 1, "1_3": "foobar", "1_4_5": "barfoo"},
                 json.loads(r.outputs["test_case_7"].read()),
+            )
+
+    def test_stringify_objects(self):
+        with Relationalize("test_case_7_stringify_objects", create_local_buffer(), stringify_objects=True) as r:
+            r.relationalize([CASE_7])
+            self.assertListEqual(["test_case_7_stringify_objects"], list(r.outputs.keys()))
+            r.outputs["test_case_7_stringify_objects"].seek(0)
+            self.assertDictEqual(
+                {"1": str({"2": 1, "3": "foobar", "4": {"5": "barfoo"}})},
+                json.loads(r.outputs["test_case_7_stringify_objects"].read()),
             )
 
     def test_list_list_struct(self):

--- a/test/relationalize.test.py
+++ b/test/relationalize.test.py
@@ -265,14 +265,14 @@ class RelationalizeTest(unittest.TestCase):
                 json.loads(sub_file_lines[3])["_rid_"],
             )
 
-    def test_stringify_arrays(self):
-        with Relationalize("test_case_6_stringify_arrays", create_local_buffer(), stringify_arrays=True) as r:
+    def test_ignore_arrays(self):
+        with Relationalize("test_case_6_ignore_arrays", create_local_buffer(), ignore_arrays=True) as r:
             r.relationalize([CASE_6])
-            self.assertListEqual(["test_case_6_stringify_arrays"], list(r.outputs.keys()))
-            r.outputs["test_case_6_stringify_arrays"].seek(0)
+            self.assertListEqual(["test_case_6_ignore_arrays"], list(r.outputs.keys()))
+            r.outputs["test_case_6_ignore_arrays"].seek(0)
             self.assertDictEqual(
-                {"1": str([{"2": "foobar", "3": [1, 2]}, {"2": "barfoo", "3": [3, 4]}]), "2": "foobar"},
-                json.loads(r.outputs["test_case_6_stringify_arrays"].read()),
+                {"1": [{"2": "foobar", "3": [1, 2]}, {"2": "barfoo", "3": [3, 4]}], "2": "foobar"},
+                json.loads(r.outputs["test_case_6_ignore_arrays"].read()),
             )
 
     def test_flatten_struct(self):
@@ -287,14 +287,14 @@ class RelationalizeTest(unittest.TestCase):
                 json.loads(r.outputs["test_case_7"].read()),
             )
 
-    def test_stringify_objects(self):
-        with Relationalize("test_case_7_stringify_objects", create_local_buffer(), stringify_objects=True) as r:
+    def test_ignore_objects(self):
+        with Relationalize("test_case_7_ignore_objects", create_local_buffer(), ignore_objects=True) as r:
             r.relationalize([CASE_7])
-            self.assertListEqual(["test_case_7_stringify_objects"], list(r.outputs.keys()))
-            r.outputs["test_case_7_stringify_objects"].seek(0)
+            self.assertListEqual(["test_case_7_ignore_objects"], list(r.outputs.keys()))
+            r.outputs["test_case_7_ignore_objects"].seek(0)
             self.assertDictEqual(
-                {"1": str({"2": 1, "3": "foobar", "4": {"5": "barfoo"}})},
-                json.loads(r.outputs["test_case_7_stringify_objects"].read()),
+                {"1": {"2": 1, "3": "foobar", "4": {"5": "barfoo"}}},
+                json.loads(r.outputs["test_case_7_ignore_objects"].read()),
             )
 
     def test_list_list_struct(self):

--- a/test/schema.test.py
+++ b/test/schema.test.py
@@ -69,7 +69,7 @@ CREATE TABLE IF NOT EXISTS "public"."test" (
 
 # DDLs expected for dialect = Flink
 CASE_1_DDL_FLINK = """
-CREATE TABLE IF NOT EXISTS public.`test` (
+CREATE TABLE IF NOT EXISTS `public.test` (
     `1` INT
     , `2` STRING
     , `3` BOOLEAN
@@ -90,7 +90,7 @@ CREATE TABLE IF NOT EXISTS `test` (
 """.strip()
 
 CASE_2_DDL_FLINK = """
-CREATE TABLE IF NOT EXISTS public.`test` (
+CREATE TABLE IF NOT EXISTS `public.test` (
     `1_int` INT
     , `1_str` STRING
     , `2_float` FLOAT
@@ -102,14 +102,14 @@ CREATE TABLE IF NOT EXISTS public.`test` (
 """.strip()
 
 CASE_6_DDL_FLINK = """
-CREATE TABLE IF NOT EXISTS public.`test` (
+CREATE TABLE IF NOT EXISTS `public.test` (
     `_id` STRING PRIMARY KEY NOT ENFORCED
     , `not_id` STRING
 );
 """.strip()
 
 CASE_7_DDL_FLINK = """
-CREATE TABLE IF NOT EXISTS public.`test` (
+CREATE TABLE IF NOT EXISTS `public.test` (
     `1` TIMESTAMP_LTZ
     , `2` TIMESTAMP_LTZ
     , `3` TIMESTAMP_LTZ


### PR DESCRIPTION
`Relationalize` class:
- `stringify_arrays `--> `ignore_arrays`
- new `ignore_objects` argument

SQL dialect/stringifying => implemented in the `Schema` class
- new column types: str_arr, str_obj
- added support for JSONB type in Postgres